### PR TITLE
correct handling of stimulus_id parameter

### DIFF
--- a/env.py
+++ b/env.py
@@ -454,7 +454,7 @@ class Env(object):
             if stimulus_id is None:
                 self.stimulus_id = None
             else:
-                if stimulus_id in self.stimulus_config['Arena'][arena_id].stimuli:
+                if stimulus_id in self.stimulus_config['Arena'][arena_id].trajectories:
                     self.stimulus_id = stimulus_id
                 else:
                     raise RuntimeError('init_stimulus_config: stimulus id parameter not found in stimulus configuration')

--- a/jobscripts/run_microcircuit.sh
+++ b/jobscripts/run_microcircuit.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-mpirun.mpich -n 4 python3 ./scripts/run_network.py  \
+mpirun.mpich -n 8 python3 ./scripts/run_network.py  \
     --config-file=Microcircuit_Small.yaml  \
     --arena-id=A \
+    --stimulus-id=Diag \
     --template-paths=templates \
     --dataset-prefix="./datasets" \
     --results-path=results \
     --io-size=1 \
-    --tstop=50 \
+    --tstop=500 \
     --v-init=-75 \
     --results-write-time=60 \
     --stimulus-onset=0.0 \

--- a/scripts/run_network.py
+++ b/scripts/run_network.py
@@ -8,7 +8,6 @@ import os, sys
 import numpy as np
 import click
 from mpi4py import MPI
-import dentate
 from MiV import network
 from MiV.env import Env
 from MiV.utils import list_find, config_logging
@@ -35,7 +34,7 @@ sys.excepthook = mpi_excepthook
 
 @click.command()
 @click.option("--arena-id", required=True, type=str,
-              help='name of arena used for spatial stimulus')
+              help='name of arena used for stimulus')
 @click.option("--cell-selection-path", required=False, type=click.Path(exists=True, file_okay=True, dir_okay=False),
               help='name of file specifying subset of cells gids to be instantiated')
 @click.option("--config-file", required=True, type=str, help='model configuration file name')
@@ -110,9 +109,9 @@ def main(arena_id, cell_selection_path, config_file, template_paths, hoc_lib_pat
     if profile_time:
         from MiV.network import init, run
         import cProfile
-        cProfile.runctx('init(env)', None, locals(), filename='dentate_profile_init')
+        cProfile.runctx('init(env)', None, locals(), filename='MiV_profile_init')
         if not dry_run:
-            cProfile.runctx('run(env)', None, locals(), filename='dentate_profile_run')
+            cProfile.runctx('run(env)', None, locals(), filename='MiV_profile_run')
     else:
         network.init(env)
         if not dry_run:


### PR DESCRIPTION
Removing a few residual references to dentate, and making sure stimulus_id is used in place of trajectory_id.