### PR TITLE
Cluster setup scripts

### DIFF
--- a/docs/tutorial/installation.md
+++ b/docs/tutorial/installation.md
@@ -152,4 +152,4 @@ export PATH=<NeuroH5 installation path>/bin:$PATH
 ## Tools and scripts to aid cluster usage
 
 - [How to install and configure as module](https://github.com/GazzolaLab/MiV-Simulator/tree/latest/support/cluster)
-- [Machinable: A modular system to manage research code](https://machinable.org://machinable.org/)
+- [Machinable: A modular system to manage research code](https://machinable.org)

--- a/docs/tutorial/installation.md
+++ b/docs/tutorial/installation.md
@@ -59,7 +59,9 @@ CMAKE_BUILD_PARALLEL_LEVEL=8 pip install .
 
 For architecture-level optimization, some of the core libraries should be built within the worker node.
 
-> **NOTE:** Make sure to run on a worker node, not the login-node!
+:::{note}
+Make sure to run on a worker node, not the login-node!
+:::
 
 ### Necessary Modules
 
@@ -146,3 +148,8 @@ cmake .
 make -j4
 export PATH=<NeuroH5 installation path>/bin:$PATH
 ```
+
+## Tools and scripts to aid cluster usage
+
+- [How to install and configure as module](https://github.com/GazzolaLab/MiV-Simulator/tree/latest/support/cluster)
+- [Machinable: A modular system to manage research code](https://machinable.org://machinable.org/)

--- a/support/cluster/README.md
+++ b/support/cluster/README.md
@@ -1,0 +1,48 @@
+# Tools and scripts to aid cluster usage
+
+## Module installation
+
+### Installation scripts
+
+Here we provide example scripts to setup modules for the cluster environment.
+
+```bash
+# e.g. `bash <installation script> <path to install>
+bash expanse.sh ${HOME}/workspace/MiV
+```
+
+1. [Expanse(UCSD)](expanse.sh)
+
+> Setting up dependencies might take some time (0.5-1 hr).
+> Depending on the user allocation and type of available nodes, some modules within the script might needs adjustments. Here, the scripts are intended to serve as a template. If you have successful setup on any other cluster or environment, please feel free to make PR and append the setup scripts here.
+
+### Module usage
+
+```bash
+module use ${HOME}/workspace/MiV/modules
+module load miv-simulator
+conda activate ${HOME}/workspace/conda_env/miv
+```
+
+```bash
+$ module avail
+------------------------------------------------- test/modules -------------------------------------------------
+   miv-simulator (L)
+```
+
+### Module help strings
+
+```bash
+$ module help miv-simulator
+
+----------------------------------- Module Specific Help for "miv-simulator" -----------------------------------
+This module is expected to be used with python-environment conda_env/miv.
+We recommend to make a clone environment to protect original environment setup.
+```
+
+```bash
+$ module whatis miv-simulator
+miv-simulator       : Require C/C++ libraries and Python modules for MiV-Simulator.
+miv-simulator       : The module includes phdf5-1.12.1, NEURON-8.2.1, and NeuroH5
+miv-simulator       : Loading this module will additionally load openmpi, cmake, and anaconda.
+```

--- a/support/cluster/expanse.sh
+++ b/support/cluster/expanse.sh
@@ -3,7 +3,7 @@
 read -rd '' globalhelp <<-EOF
     how to use setup.sh
     -------------------
-    ./miv_setup.sh <options>
+    ./expanse.sh <options>
 
     options and explanations
     ---------------------------
@@ -181,9 +181,9 @@ proc ModulesHelp { } {
     puts stdout "We recommend to make a clone environment to protect original environment setup."
 }
 
-module-whatis "Require C/C++ libraries and Python modules for MiV-Simulator."
-module-whatis "The module includes phdf5-$HDF5_VER, NEURON-$NEURON_VER, and NeuroH5"
-module-whatis "Loading this module will additionally load openmpi, cmake, and anaconda."
+module-whatis "Necessary C/C++ libraries and Python modules for MiV-Simulator."
+module-whatis "The module includes phdf5-$HDF5_VER, NEURON-$NEURON_VER, NeuroH5, and miv-simulator."
+module-whatis "Loading this module will additionally load openmpi."
 
 module load $MPI_LIBRARY
 

--- a/support/cluster/expanse.sh
+++ b/support/cluster/expanse.sh
@@ -1,0 +1,156 @@
+#-- CLI Prompts --#
+
+read -rd '' globalhelp <<-EOF
+    how to use setup.sh
+    -------------------
+    ./expanse.sh <options>
+
+    options and explanations
+    ---------------------------
+      help : Print this help message
+
+      path : Required. Path to install dependencies/modules (created if it does not exist).
+EOF
+if [[ $1 =~ ^([hH][eE][lL][pP]|[hH])$ ]]; then
+    echo "${globalhelp}"
+    exit 1
+fi
+
+if [ $# != 1 ]; then
+    echo "You must pass one argument to setup modules, which"
+    echo "is the directory where you want the dependencies to be built."
+    exit 1
+fi
+
+set -e
+source ~/.bashrc
+
+#-- Set Modules --#
+
+module purge
+
+# SDSC Expanse - specific load
+module load shared
+module load cpu/0.15.4
+module load slurm/expanse/21.08.8
+module load sdsc/1.0
+
+# Dependencies
+module load gcc/10.2.0
+module load openmpi cmake anaconda3
+
+echo "DEBUG: Check cmake version:"
+cmake --version
+
+#-- Compiler Setup
+
+echo "DEBUG: Check compiler versions:"
+CC=mpicc
+CXX=mpicxx
+MPICC=mpicc
+MPICXX=mpicxx
+echo "C Compiler: " $CC
+echo "C++ Compiler: " $CXX
+echo "MPI-C Compiler: " $MPICC
+echo "MPI-C++ Compiler: " $MPICXX
+$MPICC --version
+$MPICXX --version
+
+#-- Installation --#
+
+START_DIR=`pwd`
+dep_dir=`realpath $1`
+mkdir -p $dep_dir
+cd $dep_dir
+
+# Configuration
+HDF5_MAJOR_VER=1
+HDF5_MINOR_VER=12
+HDF5_PATCH_VER=1
+export HDF5_VER=${HDF5_MAJOR_VER}.${HDF5_MINOR_VER}.${HDF5_PATCH_VER}
+export NEURON_VER=8.2.1
+
+# Setup Python
+
+PYTHON_VER=3.10
+conda create -y -p $dep_dir/conda_env/miv python==$PYTHON_VER
+PYTHON=$dep_dir/conda_env/miv/bin/python
+PIP=$dep_dir/conda_env/miv/bin/pip
+conda activate $dep_dir/conda_env/miv
+echo "DEBUG: Check python/pip version and path:"
+echo "   (Make sure python/pip from conda environment is being used.)"
+which $PYTHON
+$PYTHON --version
+which $PIP
+$PIP --version
+
+# Install Poetry
+#pip install poetry
+#poetry --version
+
+# Install Parallel HDF5 (source)
+wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${HDF5_MAJOR_VER}.${HDF5_MINOR_VER}/hdf5-${HDF5_VER}/src/hdf5-${HDF5_VER}.tar.gz
+tar -xzf hdf5-${HDF5_VER}.tar.gz
+cd hdf5-${HDF5_VER}
+./configure --prefix=$PWD/build --enable-parallel --enable-shared
+make
+make install
+export HDF5_SOURCE=$PWD
+export HDF5_ROOT=$PWD
+export PATH=$HDF5_SOURCE/build:$HDF5_SOURCE/build/bin:$PATH
+# export LD_LIBRARY_PATH=$HDF5_SOURCE/build/lib:$LD_LIBRARY_PATH
+# HDF5 test:
+# NPROCS=4 make check-p
+cd $dep_dir
+
+# Install MPI4PY (pip)
+env MPICC="$MPICC --shared" $PIP install --no-cache-dir mpi4py
+$PIP install numpy
+
+# Install h5py (pip)
+HDF5_MPI="ON" HDF5_DIR=${HDF5_SOURCE}/build $PIP install --no-binary=h5py --no-deps h5py
+
+# Install NeuroH5 (pip, source)
+git clone https://github.com/iraikov/neuroh5.git
+$PIP install --no-deps ./neuroh5
+cd neuroh5
+cmake .
+make
+export NEUROH5_SOURCE=$dep_dir/neuroh5
+#export PATH=$NEUROH5_SOURCE/bin:$PATH
+#which h5copy
+#which neurotrees_import
+cd $dep_dir
+
+# Install Neuron (pip)
+$PIP install --no-cache-dir neuron==${NEURON_VER}
+
+# Install MiV Simulator (pip)
+git clone https://github.com/GazzolaLab/MiV-Simulator
+$PIP install --no-cache-dir ./MiV-Simulator
+
+#-- Setup Module --#
+mkdir -p $dep_dir/modules
+cat >$dep_dir/modules/miv-simulator <<EOF
+#%Module1.0
+#
+
+proc ModulesHelp { } {
+    puts stdout "This module is expected to be used with python-environment conda_env/miv."
+    puts stdout "We recommend to make a clone environment to protect original environment setup."
+}
+
+module-whatis "Require C/C++ libraries and Python modules for MiV-Simulator."
+module-whatis "The module includes phdf5-$HDF5_VER, NEURON-$NEURON_VER, and NeuroH5"
+module-whatis "Loading this module will additionally load openmpi, cmake, and anaconda."
+
+prepend-path PATH "$HDF5_SOURCE/build:$HDF5_SOURCE/build/bin"
+prepend-path PATH "$NEUROH5_SOURCE/bin"
+EOF
+
+#-- Terminate --#
+# Remove Configuration
+conda deactivate
+
+echo "MiV Dependency setup completed."
+cd $START_DIR

--- a/support/cluster/expanse.sh
+++ b/support/cluster/expanse.sh
@@ -3,7 +3,7 @@
 read -rd '' globalhelp <<-EOF
     how to use setup.sh
     -------------------
-    ./expanse.sh <options>
+    ./miv_setup.sh <options>
 
     options and explanations
     ---------------------------
@@ -27,6 +27,8 @@ source ~/.bashrc
 
 #-- Set Modules --#
 
+MPI_LIBRARY=openmpi
+
 module purge
 
 # SDSC Expanse - specific load
@@ -37,7 +39,8 @@ module load sdsc/1.0
 
 # Dependencies
 module load gcc/10.2.0
-module load openmpi cmake anaconda3
+module load cmake anaconda3
+module load $MPI_LIBRARY
 
 echo "DEBUG: Check cmake version:"
 cmake --version
@@ -69,6 +72,7 @@ HDF5_MINOR_VER=12
 HDF5_PATCH_VER=1
 export HDF5_VER=${HDF5_MAJOR_VER}.${HDF5_MINOR_VER}.${HDF5_PATCH_VER}
 export NEURON_VER=8.2.1
+export ZLIB_VER=1.2.12
 
 # Setup Python
 
@@ -76,6 +80,7 @@ PYTHON_VER=3.10
 conda create -y -p $dep_dir/conda_env/miv python==$PYTHON_VER
 PYTHON=$dep_dir/conda_env/miv/bin/python
 PIP=$dep_dir/conda_env/miv/bin/pip
+CMAKE_PREFIX_PATH=$dep_dir/conda_env/miv:$CMAKE_PREFIX_PATH
 conda activate $dep_dir/conda_env/miv
 echo "DEBUG: Check python/pip version and path:"
 echo "   (Make sure python/pip from conda environment is being used.)"
@@ -84,15 +89,29 @@ $PYTHON --version
 which $PIP
 $PIP --version
 
-# Install Poetry
-#pip install poetry
-#poetry --version
+# Build and install zlib
+#mkdir -p ${BUILDDIR}
+#cd ${BUILDDIR}
+#wget http://www.zlib.net/zlib-${ZLIB_VER}.tar.gz
+#tar -zxvf zlib-${ZLIB_VER}.tar.gz
+#rm zlib-${ZLIB_VER}.tar.gz
+#cd zlib-${ZLIB_VER}
+#./configure --prefix=$PWD/build
+#make check #-j 4
+#make install
+#export ZLIB_SOURCE=$PWD
+#cd $dep_dir
 
 # Install Parallel HDF5 (source)
 wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${HDF5_MAJOR_VER}.${HDF5_MINOR_VER}/hdf5-${HDF5_VER}/src/hdf5-${HDF5_VER}.tar.gz
 tar -xzf hdf5-${HDF5_VER}.tar.gz
+rm hdf5-${HDF5_VER}.tar.gz
 cd hdf5-${HDF5_VER}
-./configure --prefix=$PWD/build --enable-parallel --enable-shared
+./configure \
+    --prefix=$PWD/build \
+    --enable-parallel \
+    --enable-shared
+#   --with-zlib=$ZLIB_SOURCE
 make
 make install
 export HDF5_SOURCE=$PWD
@@ -110,6 +129,31 @@ $PIP install numpy
 # Install h5py (pip)
 HDF5_MPI="ON" HDF5_DIR=${HDF5_SOURCE}/build $PIP install --no-binary=h5py --no-deps h5py
 
+# Install Neuron (source)
+# https://github.com/BlueBrain/nmodl/blob/60249f1f795b84a20fb0e9732374bdfec1f878e5/CMakeLists.txt#L171-L175
+$PIP install --no-cache-dir Jinja2 sympy Cython
+git clone --recurse-submodules -j8 https://github.com/neuronsimulator/nrn.git -b ${NEURON_VER}
+cd nrn
+$PIP install -r nrn_requirements.txt
+mkdir build
+cd build
+cmake .. \
+    -DNRN_ENABLE_INTERVIEWS=OFF \
+    -DNRN_ENABLE_PYTHON=ON \
+    -DNRN_ENABLE_MPI=ON \
+    -DNRN_ENABLE_RX3D=ON \
+    -DNRN_ENABLE_CORENEURON=ON \
+    -DPYTHON_EXECUTABLE=$PYTHON \
+    -DCMAKE_INSTALL_PREFIX=../install \
+    -DCORENRN_ENABLE_NMODL=ON \
+    -DCMAKE_C_COMPILER=$MPICC \
+    -DCMAKE_CXX_COMPILER=$MPICXX
+cmake --build . --parallel 8 --target install
+export NRN_SOURCE=$PWD
+export PATH=$NRN_SOURCE/bin:$PATH
+export PYTHONPATH=$NRN_SOURCE/lib/python:$PYTHONPATH
+cd $dep_dir
+
 # Install NeuroH5 (pip, source)
 git clone https://github.com/iraikov/neuroh5.git
 $PIP install --no-deps ./neuroh5
@@ -121,9 +165,6 @@ export NEUROH5_SOURCE=$dep_dir/neuroh5
 #which h5copy
 #which neurotrees_import
 cd $dep_dir
-
-# Install Neuron (pip)
-$PIP install --no-cache-dir neuron==${NEURON_VER}
 
 # Install MiV Simulator (pip)
 git clone https://github.com/GazzolaLab/MiV-Simulator
@@ -144,8 +185,12 @@ module-whatis "Require C/C++ libraries and Python modules for MiV-Simulator."
 module-whatis "The module includes phdf5-$HDF5_VER, NEURON-$NEURON_VER, and NeuroH5"
 module-whatis "Loading this module will additionally load openmpi, cmake, and anaconda."
 
+module load $MPI_LIBRARY
+
 prepend-path PATH "$HDF5_SOURCE/build:$HDF5_SOURCE/build/bin"
 prepend-path PATH "$NEUROH5_SOURCE/bin"
+prepend-path PATH "$NRN_SOURCE/bin"
+prepend-path PYTHONPATH "$NRN_SOURCE/lib/python"
 EOF
 
 #-- Terminate --#


### PR DESCRIPTION
## Purpose

- _Archive_ setup script (working version) for commonly-available clusters
- Enhance availability for other collaborators

## Feature

- `support/cluster` directory to add cluster setup scripts.
  - add `expanse` setup script
- `readme` file.

## Description

- dependencies (HDF5-Parallel, NeuroH5, Neuron) built with a common compiler
- paths setup as a module

```bash
$ module avail
------------------------------------------------- test/modules -------------------------------------------------
   miv-simulator (L)
```
```bash
$ module help miv-simulator

----------------------------------- Module Specific Help for "miv-simulator" -----------------------------------
This module is expected to be used with python-environment conda_env/miv.
```
```bash
$ module whatis miv-simulator
miv-simulator       : Require C/C++ libraries and Python modules for MiV-Simulator.
miv-simulator       : The module includes phdf5-1.12.1, NEURON-8.2.1, and NeuroH5
miv-simulator       : Loading this module will additionally load openmpi, cmake, and anaconda.
```

## TODO

- [x] Check the installation in compute node
- [x] Add link in documentation