### PR TITLE
Custom spike train interface fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-tests/mechanisms/compiled
+tests/**/compiled
 examples/datasets
 
 # Byte-compiled / optimized / DLL files

--- a/src/miv_simulator/interface/prepare_data.py
+++ b/src/miv_simulator/interface/prepare_data.py
@@ -20,10 +20,15 @@ class PrepareData(Experiment):
         return self.local_directory(f"data/simulation/{path}.h5")
 
     def on_compute_predicate(self):
+        def generate_uid(use):
+            if getattr(use, "refreshed_at", None) is not None:
+                return f"{use.experiment_id}-{use.refreshed_at}"
+            return use.experiment_id
+
         return {
             "uses*": sorted(
                 map(
-                    lambda x: x.experiment_id,
+                    generate_uid,
                     self.uses,
                 )
             )

--- a/src/miv_simulator/interface/run.py
+++ b/src/miv_simulator/interface/run.py
@@ -43,6 +43,7 @@ class RunNetwork(Experiment):
         spike_input_namespace: Optional[str] = None
         spike_input_attr: Optional[str] = None
         record_syn_spike_count: bool = False
+        templates: str = "templates"
         mechanisms: str = "./mechanisms"
         t_stop: int = 1
         v_init: float = -75.0
@@ -72,7 +73,7 @@ class RunNetwork(Experiment):
         self.env = env = Env(
             comm=MPI.COMM_WORLD,
             config={**blueprint, **data_configuration},
-            template_paths="templates",
+            template_paths=self.config.templates,
             hoc_lib_path=None,
             dataset_prefix="",
             results_path=self.local_directory("data"),
@@ -128,5 +129,6 @@ class RunNetwork(Experiment):
         rank = comm.Get_rank()
         return rank == 0
 
-    def on_after_dispatch(self):
-        return miv_simulator.network.shutdown(self.env)
+    def on_after_dispatch(self, success: bool):
+        if success:
+            miv_simulator.network.shutdown(self.env)


### PR DESCRIPTION
- [x] fix MPI shutdown for exception propagation
- [x] detect custom spike data update to regenerate input data automatically
- [ ] verify use of custom spike data