### PR TITLE
Fix/import optostim

### DIFF
--- a/src/miv_simulator/network.py
+++ b/src/miv_simulator/network.py
@@ -22,6 +22,7 @@ from miv_simulator.utils import io as io_utils
 from miv_simulator.utils import neuron as neuron_utils
 from miv_simulator.utils import profile_memory, simtime, zip_longest
 from miv_simulator.utils.neuron import h
+from miv_simulator.opto.run import *
 
 if hasattr(h, "nrnmpi_init"):
     h.nrnmpi_init()

--- a/src/miv_simulator/plotting.py
+++ b/src/miv_simulator/plotting.py
@@ -1401,8 +1401,8 @@ def plot_lfp(
             filtered_v = apply_filter(
                 v,
                 butter_bandpass_filter(
-                    max(bandpass_filter[0], 1.0),
-                    bandpass_filter[1],
+                    max(frequency_range[0], 1.0),
+                    frequency_range[1],
                     Fs,
                     order=2,
                 ),
@@ -1490,9 +1490,9 @@ def plot_lfp(
             if bandpass_filter:
                 filtered_v = apply_filter(
                     v,
-                    butter_bandpass(
-                        max(bandpass_filter[0], 1.0),
-                        bandpass_filter[1],
+                    butter_bandpass_filter(
+                        max(frequency_range[0], 1.0),
+                        frequency_range[1],
                         Fs,
                         order=2,
                     ),

--- a/src/miv_simulator/utils/utils.py
+++ b/src/miv_simulator/utils/utils.py
@@ -1150,7 +1150,7 @@ def signal_power_spectrogram(signal, fs, window_size, window_overlap):
     from scipy.signal import get_window, spectrogram
 
     nperseg = window_size
-    win = get_window("hanning", nperseg)
+    win = get_window("hamming", nperseg)
     noverlap = int(window_overlap * nperseg)
 
     f, t, sxx = spectrogram(
@@ -1162,7 +1162,7 @@ def signal_power_spectrogram(signal, fs, window_size, window_overlap):
 
 def signal_psd(s, Fs, frequency_range=(0, 500), window_size=4096, overlap=0.9):
     nperseg = window_size
-    win = signal.get_window("hanning", nperseg)
+    win = signal.get_window("hamming", nperseg)
     noverlap = int(overlap * nperseg)
 
     freqs, psd = signal.welch(


### PR DESCRIPTION
Minor bug fixes:
1) Import OptoStim class in network.py
2) Change instances of butter_bandpass to butter_bandpass_filter in plot_lfp 
3) Change bandpass_filter list to frequency range while calling the bandpass filter. 
4) Replace hanning window to hamming in signal psd