### PR TITLE
[minor] scipy.signal.hann -> scipy.signal.windows.hann

### DIFF
--- a/src/miv_simulator/stimulus.py
+++ b/src/miv_simulator/stimulus.py
@@ -200,7 +200,8 @@ def get_equilibration(env: AbstractEnv) -> Tuple[ndarray, int]:
             env.stimulus_config["Equilibration Duration"]
             / env.stimulus_config["Temporal Resolution"]
         )
-        from scipy.signal import hann
+        from scipy.signal.windows import hann
+        
 
         equilibrate_hann = hann(2 * equilibrate_len)[:equilibrate_len]
         equilibrate = (equilibrate_hann, equilibrate_len)


### PR DESCRIPTION
The namespace for `hann` has changed.