### PR TITLE
[minor] bug on old run script default values

### DIFF
--- a/src/scripts/run_network.py
+++ b/src/scripts/run_network.py
@@ -196,6 +196,7 @@ sys.excepthook = mpi_excepthook
 @click.option(
     "--coordinates-namespace",
     required=False,
+    default="Coordinates",
     type=str,
     help="namespace for coordinates when cells without morphologies are instantiated",
 )


### PR DESCRIPTION
Without the default value specified for `click` option, `None` will be used.